### PR TITLE
fix: hide facebook auth button temporarily

### DIFF
--- a/src/components/AuthPage/LoginForm.tsx
+++ b/src/components/AuthPage/LoginForm.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 
 import { getFirebaseErrorMessage } from "./firebaseError";
+import { FACEBOOK_AUTH_UI_ENABLED } from "./auth-ui-flags";
 import { FacebookIcon, GoogleIcon } from "./icons";
 import { loginSchema } from "./schema";
 
@@ -158,17 +159,19 @@ export default function LoginForm() {
         >
           Войти через Google <GoogleIcon />
         </Button>
-        <Button
-          type="button"
-          onClick={(event) =>
-            signInWithFacebook(event, form.setError, navigate)
-          }
-          variant="outline"
-          className="mt-2 w-full bg-white"
-          aria-label="Войти через Facebook"
-        >
-          Войти через Facebook <FacebookIcon />
-        </Button>
+        {FACEBOOK_AUTH_UI_ENABLED && (
+          <Button
+            type="button"
+            onClick={(event) =>
+              signInWithFacebook(event, form.setError, navigate)
+            }
+            variant="outline"
+            className="mt-2 w-full bg-white"
+            aria-label="Войти через Facebook"
+          >
+            Войти через Facebook <FacebookIcon />
+          </Button>
+        )}
       </form>
     </Form>
   );

--- a/src/components/AuthPage/RegisterForm.tsx
+++ b/src/components/AuthPage/RegisterForm.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 
 import { getFirebaseErrorMessage } from "./firebaseError";
+import { FACEBOOK_AUTH_UI_ENABLED } from "./auth-ui-flags";
 import { FacebookIcon, GoogleIcon } from "./icons";
 import { registerSchema } from "./schema";
 
@@ -232,17 +233,19 @@ export default function RegisterForm() {
           >
             Зарегистрироваться через Google <GoogleIcon />
           </Button>
-          <Button
-            type="button"
-            onClick={(event) =>
-              signInWithFacebook(event, form.setError, navigate)
-            }
-            variant="outline"
-            className="mt-2 h-auto w-full whitespace-normal bg-white"
-            aria-label="Зарегистрироваться через Facebook"
-          >
-            Зарегистрироваться через Facebook <FacebookIcon />
-          </Button>
+          {FACEBOOK_AUTH_UI_ENABLED && (
+            <Button
+              type="button"
+              onClick={(event) =>
+                signInWithFacebook(event, form.setError, navigate)
+              }
+              variant="outline"
+              className="mt-2 h-auto w-full whitespace-normal bg-white"
+              aria-label="Зарегистрироваться через Facebook"
+            >
+              Зарегистрироваться через Facebook <FacebookIcon />
+            </Button>
+          )}
         </form>
       )}
     </Form>

--- a/src/components/AuthPage/auth-ui-flags.ts
+++ b/src/components/AuthPage/auth-ui-flags.ts
@@ -1,0 +1,2 @@
+/** Temporarily hidden until Facebook Developer App is configured. */
+export const FACEBOOK_AUTH_UI_ENABLED = false;


### PR DESCRIPTION
Temporarily hid Facebook auth buttons on login and registration forms until the Facebook Developer App is configured.